### PR TITLE
fix: #56 Correct spelling in README for deep learning frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Further topics to work into the progression above:
 - Programming languages: Assembly, C, Python
 - Data types: Integer, Float, String (ASCII, Unicode, UTF-8)
 - Tensor: shapes, views, strides, contiguous, ...
-- Deep Learning frameowrks: PyTorch, JAX
+- Deep Learning frameworks: PyTorch, JAX
 - Neural Net Architecture: GPT (1,2,3,4), Llama (RoPE, RMSNorm, GQA), MoE, ...
 - Multimodal: Images, Audio, Video, VQVAE, VQGAN, diffusion
 


### PR DESCRIPTION
Detailed description:
- Fixed a typo in the README file where "frameowrks" was corrected to "frameworks."

Testing:
- Reviewed the README file to confirm that the spelling is now correct.

Closes related issues:
- Closes #56